### PR TITLE
Remove the backslash from the file path formed by GetEmojiImageAsync.…

### DIFF
--- a/discordbot/Functions.cs
+++ b/discordbot/Functions.cs
@@ -474,7 +474,7 @@ namespace Mafiabot
         {
             return await Task.Run(() =>
             {
-                FileStream image = File.OpenRead($"{Config.EmojiImageFolderPath}\\{fileName}");
+                FileStream image = File.OpenRead($"{Config.EmojiImageFolderPath}{fileName}");
                 return image;
             });
         }


### PR DESCRIPTION
… This makes the function crossplatform, rather than windows exclusive.